### PR TITLE
chore: tidy .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,15 @@ outputs/
 .ipynb_checkpoints/
 .DS_Store
 Thumbs.db
+
+# --- Project specific (medmnist-mini-bench) ---
+# training outputs & caches (do not version control)
+outputs/
+data/
+# notebooks cache
+.ipynb_checkpoints/
+# macOS & editors
+.DS_Store
+*.swp
+# keep assets (images/metrics for README) versioned:
+#!assets/


### PR DESCRIPTION
Added common ignores for outputs, data cache, Jupyter checkpoints, and macOS files.